### PR TITLE
feat: add `liara init` command

### DIFF
--- a/src/base.ts
+++ b/src/base.ts
@@ -74,19 +74,18 @@ export interface IProject {
   created_at: string;
   isDeployed: boolean;
 }
-interface IDisk {
-  name: string;
-  size: number;
-  updatedAt: string;
-  createdAt: string;
-  filebrowserUrl: string;
-}
 interface IMount {
   name: string;
   mountedTo: string;
 }
 export interface IGetDiskResponse {
-  disks: IDisk[];
+  disks: {
+    name: string;
+    size: number;
+    updatedAt: string;
+    createdAt: string;
+    filebrowserUrl: string;
+  }[];
   mounts: IMount[];
 }
 

--- a/src/base.ts
+++ b/src/base.ts
@@ -26,6 +26,8 @@ import {
   GLOBAL_CONF_PATH,
   GLOBAL_CONF_VERSION,
 } from './constants.js';
+import { getDefaultPort } from './utils/get-port.js';
+import validatePort from './utils/validate-port.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -309,7 +311,17 @@ Please check your network connection.`);
       throw error;
     }
   }
+  async promptPort(platform: string): Promise<number> {
+    const { port } = (await inquirer.prompt({
+      name: 'port',
+      type: 'input',
+      default: getDefaultPort(platform),
+      message: 'Enter the port your app listens to:',
+      validate: validatePort,
+    })) as { port: number };
 
+    return port;
+  }
   async getCurrentAccount(): Promise<IAccount> {
     const accounts = (await this.readGlobalConfig()).accounts;
     const accName = Object.keys(accounts).find(

--- a/src/base.ts
+++ b/src/base.ts
@@ -28,6 +28,7 @@ import {
 } from './constants.js';
 import { getDefaultPort } from './utils/get-port.js';
 import validatePort from './utils/validate-port.js';
+import { Interface } from 'node:readline';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -73,20 +74,6 @@ export interface IProject {
   project_id: string;
   created_at: string;
   isDeployed: boolean;
-}
-interface IMount {
-  name: string;
-  mountedTo: string;
-}
-export interface IGetDiskResponse {
-  disks: {
-    name: string;
-    size: number;
-    updatedAt: string;
-    createdAt: string;
-    filebrowserUrl: string;
-  }[];
-  mounts: IMount[];
 }
 
 export interface IGetProjectsResponse {

--- a/src/base.ts
+++ b/src/base.ts
@@ -311,17 +311,6 @@ Please check your network connection.`);
       throw error;
     }
   }
-  async promptPort(platform: string): Promise<number> {
-    const { port } = (await inquirer.prompt({
-      name: 'port',
-      type: 'input',
-      default: getDefaultPort(platform),
-      message: 'Enter the port your app listens to:',
-      validate: validatePort,
-    })) as { port: number };
-
-    return port;
-  }
   async getCurrentAccount(): Promise<IAccount> {
     const accounts = (await this.readGlobalConfig()).accounts;
     const accName = Object.keys(accounts).find(

--- a/src/base.ts
+++ b/src/base.ts
@@ -26,8 +26,6 @@ import {
   GLOBAL_CONF_PATH,
   GLOBAL_CONF_VERSION,
 } from './constants.js';
-import { getDefaultPort } from './utils/get-port.js';
-import validatePort from './utils/validate-port.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 

--- a/src/base.ts
+++ b/src/base.ts
@@ -28,7 +28,6 @@ import {
 } from './constants.js';
 import { getDefaultPort } from './utils/get-port.js';
 import validatePort from './utils/validate-port.js';
-import { Interface } from 'node:readline';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 

--- a/src/base.ts
+++ b/src/base.ts
@@ -74,6 +74,21 @@ export interface IProject {
   created_at: string;
   isDeployed: boolean;
 }
+interface IDisk {
+  name: string;
+  size: number;
+  updatedAt: string;
+  createdAt: string;
+  filebrowserUrl: string;
+}
+interface IMount {
+  name: string;
+  mountedTo: string;
+}
+export interface IGetDiskResponse {
+  disks: IDisk[];
+  mounts: IMount[];
+}
 
 export interface IGetProjectsResponse {
   projects: IProject[];

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -45,6 +45,7 @@ import CreateArchiveException from '../errors/create-archive.js';
 import IGetProjectsResponse from '../types/get-project-response.js';
 import ReachedMaxSourceSizeError from '../errors/max-source-size.js';
 import getPlatformVersion from '../services/get-platform-version.js';
+import { promptPort } from '../utils/promptPort.js';
 
 export default class Deploy extends Command {
   static description = 'deploy an app';
@@ -147,7 +148,7 @@ export default class Deploy extends Command {
 
     if (!config.port) {
       config.port =
-        getPort(config.platform) || (await this.promptPort(config.platform));
+        getPort(config.platform) || (await promptPort(config.platform));
     }
 
     this.logKeyValue('App', config.app);
@@ -765,19 +766,6 @@ Additionally, you can also retry the build with the debug flag:
       throw error;
     }
   }
-
-  async promptPort(platform: string): Promise<number> {
-    const { port } = (await inquirer.prompt({
-      name: 'port',
-      type: 'input',
-      default: getDefaultPort(platform),
-      message: 'Enter the port your app listens to:',
-      validate: validatePort,
-    })) as { port: number };
-
-    return port;
-  }
-
   getMergedConfig(flags: IFlags): IDeploymentConfig {
     const defaults = {
       path: flags.path ? flags.path : process.cwd(),

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -227,8 +227,21 @@ Afterwards, use liara deploy to deploy your project.
       }
       const versions = supportedVersions(platform);
       if (versions) {
+        let message: string | undefined;
+        if (['flask', 'django'].includes(platform)) {
+          message = 'Python version';
+        }
+        if (platform === 'laravel') {
+          message = 'Php version';
+        }
+        if (platform === 'next') {
+          message = 'Node version';
+        }
+        if (!message) {
+          message = `${platform} version: `;
+        }
         const { version } = (await inquirer.prompt({
-          message: `${platform} version: `,
+          message: message || 'Platform version',
           name: 'version',
           type: 'list',
           default: versions.defaultVersion,
@@ -290,7 +303,7 @@ Afterwards, use liara deploy to deploy your project.
     platformVersion: string | undefined,
   ): string | undefined {
     if (platformVersion) {
-      if (platform in ['flask', 'django']) {
+      if (['flask', 'django'].includes(platform)) {
         return 'pythonVersion';
       }
       if (platform == 'laravel') {

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -142,7 +142,7 @@ Afterwards, use liara deploy to deploy your app.
         cron,
       );
 
-      this.createLiaraJsonFile(configs);
+      await this.createLiaraJsonFile(configs);
     } catch (error) {
       this.spinner.stop();
       throw error;

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,0 +1,54 @@
+import { Args, Flags } from '@oclif/core';
+import fs from 'fs-extra';
+import ora, { Ora } from 'ora';
+import inquirer from 'inquirer';
+import Command, {
+  IGetDomainsResponse,
+  IProjectDetailsResponse,
+} from '../base.js';
+import IGetProjectsResponse from '../types/get-project-response.js';
+
+export default class Init extends Command {
+  static override description = 'describe the command here';
+
+  static override examples = ['<%= config.bin %> <%= command.id %>'];
+
+  static override flags = {
+    ...Command.flags,
+    force: Flags.boolean({ char: 'f' }),
+    name: Flags.string({ char: 'n', description: 'name to print' }),
+  };
+
+  public async run(): Promise<void> {
+    const { args, flags } = await this.parse(Init);
+    await this.setGotConfig(flags);
+    await this.promptProject();
+  }
+  async promptProject(): Promise<string> {
+    // this.spinner.start('Loading...\n');
+
+    try {
+      const { projects } =
+        await this.got('v1/projects').json<IGetProjectsResponse>();
+      // this.spinner.stop();
+      if (!projects.length) {
+        this.warn(
+          'Please go to https://console.liara.ir/apps and create an app, first.',
+        );
+        this.exit(1);
+      }
+
+      const { project } = (await inquirer.prompt({
+        name: 'project',
+        type: 'list',
+        message: 'Please select an app:',
+        choices: [...projects.map((project) => project.project_id)],
+      })) as { project: string };
+
+      return project;
+    } catch (error) {
+      // this.spinner.stop();
+      throw error;
+    }
+  }
+}

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,13 +1,17 @@
 import { Args, Flags } from '@oclif/core';
 import fs from 'fs-extra';
+import validatePort from '../utils/validate-port.js';
 import ora, { Ora } from 'ora';
+import { getPort, getDefaultPort } from '../utils/get-port.js';
 import inquirer from 'inquirer';
 import Command, {
   IGetDomainsResponse,
+  IProject,
   IProjectDetailsResponse,
 } from '../base.js';
 import IGetProjectsResponse from '../types/get-project-response.js';
-
+import ILiaraJSON from '../types/liara-json.js';
+import supportedVersions from '../utils/getSupportedVersions.js';
 export default class Init extends Command {
   static override description = 'describe the command here';
 
@@ -22,15 +26,31 @@ export default class Init extends Command {
   public async run(): Promise<void> {
     const { args, flags } = await this.parse(Init);
     await this.setGotConfig(flags);
-    await this.promptProject();
+    const projects = await this.getPlatformsInfo();
+    const appName = await this.promptProjectName(projects);
+    const buildLocation = await this.buildLocationPrompt();
+    const platform = this.findPlatform(projects, appName);
+    const port = await this.getAppPort(platform, appName);
+    const configs: ILiaraJSON = {
+      port,
+      app: appName,
+      build: {
+        location: buildLocation,
+      },
+    };
+    this.createLiaraJsonFile(configs);
   }
-  async promptProject(): Promise<string> {
-    // this.spinner.start('Loading...\n');
-
+  async getPlatformsInfo(): Promise<IProject[]> {
     try {
       const { projects } =
         await this.got('v1/projects').json<IGetProjectsResponse>();
-      // this.spinner.stop();
+      return projects as IProject[];
+    } catch (error) {
+      throw error;
+    }
+  }
+  async promptProjectName(projects: IProject[]): Promise<string> {
+    try {
       if (!projects.length) {
         this.warn(
           'Please go to https://console.liara.ir/apps and create an app, first.',
@@ -44,11 +64,47 @@ export default class Init extends Command {
         message: 'Please select an app:',
         choices: [...projects.map((project) => project.project_id)],
       })) as { project: string };
-
       return project;
     } catch (error) {
-      // this.spinner.stop();
       throw error;
+    }
+  }
+  findPlatform(projects: IProject[], appName: string): string {
+    const project = projects.find((project) => {
+      return project.project_id === appName;
+    });
+    return project!.type;
+  }
+  async getAppPort(platform: string, appName: string): Promise<number> {
+    const defaultPort = getPort(platform);
+    if (!defaultPort) {
+      const port = await this.promptPort(appName);
+      return port;
+    }
+    return defaultPort;
+  }
+  async buildLocationPrompt() {
+    try {
+      const { location } = (await inquirer.prompt({
+        message: 'Build location',
+        name: 'location',
+        type: 'list',
+        default: 'iran',
+        choices: ['iran', 'germany'],
+      })) as { location: string };
+      return location;
+    } catch (error) {
+      throw error;
+    }
+  }
+  async createLiaraJsonFile(configs: ILiaraJSON) {
+    try {
+      await fs.writeFile(
+        `${process.cwd()}/liara.json`,
+        JSON.stringify(configs, null, 2),
+      );
+    } catch (error) {
+      throw new Error('There was a problem while creating liara.json file!');
     }
   }
 }

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -141,7 +141,16 @@ Afterwards, use liara deploy to deploy your project.
       this.spinner.stop();
       return projects as IProject[];
     } catch (error) {
-      throw error;
+      if (error.response && error.response.statusCode === 401) {
+        throw new Error(`Authentication failed.  
+Please log in using the 'liara login' command.
+
+If you are using an API token for authentication, please consider updating your API token.  
+You can still create a sample 'liara.json' file using the 'liara init -y' command.
+`);
+      }
+      throw new Error(`There was something wrong while fetching your app info,
+        You can still use 'liara init' with it's flags. Use 'liara init --help' for command details.`);
     }
   }
   async promptProjectName(
@@ -347,9 +356,16 @@ Afterwards, use liara deploy to deploy your project.
         return disks.disks;
       }
     } catch (error) {
-      throw new Error(
-        'There was a problem while getting your app disks, Please try again later.',
-      );
+      if (error.response && error.response.statusCode === 401) {
+        throw new Error(`Authentication failed.  
+Please log in using the 'liara login' command.
+
+If you are using an API token for authentication, please consider updating your API token.  
+You can still create a sample 'liara.json' file using the 'liara init -y' command.
+`);
+      }
+      throw new Error(`There was something wrong while fetching your app info,
+         You can still use 'liara init' with it's flags. Use 'liara init --help' for command details.`);
     }
   }
   async setDiskConfigAnswer(): Promise<boolean> {

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -83,12 +83,7 @@ Afterwards, use liara deploy to deploy your app.
           const dirName = path.basename(process.cwd());
 
           const platform = detectPlatform(process.cwd());
-          const diskConfig = [
-            {
-              disk: 'media',
-              path: '/uploads/media',
-            },
-          ];
+          const diskConfig: { disk: string; path: string }[] = [];
           const configs = this.setLiaraJsonConfigs(
             getPort(platform) || 3000,
             dirName,
@@ -98,11 +93,6 @@ Afterwards, use liara deploy to deploy your app.
             diskConfig,
           );
           await this.createLiaraJsonFile(configs);
-          this.log(
-            chalk.yellow(
-              "🚫 This file is just a sample file, don't use it for deployment.",
-            ),
-          );
 
           this.exit(0);
         } catch (error) {
@@ -168,8 +158,8 @@ You can still create a sample 'liara.json' file using the 'liara init -y' comman
 `);
       }
 
-      throw new Error(`There was something wrong while fetching your app info,
-        You can still use 'liara init' with it's flags. Use 'liara init --help' for command details.`);
+      throw new Error(`There was something wrong while fetching your apps,
+        You can still use 'liara init' with its flags. Use 'liara init --help' for more details.`);
     }
   }
   async promptProjectName(
@@ -304,7 +294,7 @@ You can still create a sample 'liara.json' file using the 'liara init -y' comman
       );
       this.spinner.succeed('liara.json is successfully created!');
     } catch (error) {
-      throw new Error('There was a problem while creating liara.json file!');
+      throw new Error('There was a problem while creating liara.json!');
     }
   }
 

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -5,12 +5,13 @@ import inquirer from 'inquirer';
 import chalk from 'chalk';
 import path from 'path';
 
-import Command, { IGetDiskResponse, IProject } from '../base.js';
+import Command, { IProject } from '../base.js';
 import { getPort } from '../utils/get-port.js';
 import IGetProjectsResponse from '../types/get-project-response.js';
 import ILiaraJSON from '../types/liara-json.js';
 import supportedVersions from '../utils/getSupportedVersions.js';
 import detectPlatform from '../utils/detect-platform.js';
+import { IGetDiskResponse } from '../types/getDiskResponse.js';
 
 export default class Init extends Command {
   static override description =

--- a/src/types/getDiskResponse.ts
+++ b/src/types/getDiskResponse.ts
@@ -1,0 +1,15 @@
+export interface IDisk {
+  name: string;
+  size: number;
+  updatedAt: string;
+  createdAt: string;
+  filebrowserUrl: string;
+}
+export interface IGetDiskResponse {
+  disks: IDisk[];
+  mounts: IMount[];
+}
+interface IMount {
+  name: string;
+  mountedTo: string;
+}

--- a/src/utils/getSupportedVersions.ts
+++ b/src/utils/getSupportedVersions.ts
@@ -1,0 +1,17 @@
+const versions = {
+  dotnet: ['2.1', '2.2', '3.0', '3.1', '5.0', '6.0', '7.0', '8.0', '9.0'],
+  node: ['14', '16', '18', '20', '22'],
+  next: ['20', '22'],
+  laravel: ['8.3.0', '8.2.0', '8.1.0', '8.0.0', '7.4.0', '7.3.0', '7.2.0'],
+  php: ['8.3.0', '8.2.0', '8.1.0', '8.0.0', '7.4.0', '7.3.0', '7.2.0'],
+  python: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12'],
+  django: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12'],
+  flask: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12'],
+};
+
+type Platform = keyof typeof versions;
+
+export default function supportedVersions(platform: Platform) {
+  return versions[platform];
+}
+supportedVersions('django');

--- a/src/utils/getSupportedVersions.ts
+++ b/src/utils/getSupportedVersions.ts
@@ -22,28 +22,12 @@ const versions: IVersions = {
   node: { defaultVersion: '20', allVersions: ['14', '16', '18', '20', '22'] },
   next: { defaultVersion: '20', allVersions: ['20', '22'] },
   laravel: {
-    defaultVersion: '8.0',
-    allVersions: [
-      '8.3.0',
-      '8.2.0',
-      '8.1.0',
-      '8.0.0',
-      '7.4.0',
-      '7.3.0',
-      '7.2.0',
-    ],
+    defaultVersion: '7.4',
+    allVersions: ['8.3', '8.2', '8.1', '8.0', '7.4', '7.3', '7.2'],
   },
   php: {
     defaultVersion: '8.0',
-    allVersions: [
-      '8.3.0',
-      '8.2.0',
-      '8.1.0',
-      '8.0.0',
-      '7.4.0',
-      '7.3.0',
-      '7.2.0',
-    ],
+    allVersions: ['8.3', '8.2', '8.1', '8.0', '7.4', '7.3', '7.2'],
   },
   python: {
     defaultVersion: '3.11',

--- a/src/utils/getSupportedVersions.ts
+++ b/src/utils/getSupportedVersions.ts
@@ -14,4 +14,3 @@ type Platform = keyof typeof versions;
 export default function supportedVersions(platform: Platform) {
   return versions[platform];
 }
-supportedVersions('django');

--- a/src/utils/getSupportedVersions.ts
+++ b/src/utils/getSupportedVersions.ts
@@ -58,13 +58,7 @@ const versions: IVersions = {
     allVersions: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12'],
   },
 };
-// export const defaultVersion={
-
-// }
 
 export default function supportedVersions(platform: string) {
-  if (platform in versions) {
-    return versions[platform as keyof typeof versions];
-  }
-  return null;
+  return versions[platform as keyof typeof versions];
 }

--- a/src/utils/getSupportedVersions.ts
+++ b/src/utils/getSupportedVersions.ts
@@ -1,16 +1,70 @@
-const versions = {
-  dotnet: ['2.1', '2.2', '3.0', '3.1', '5.0', '6.0', '7.0', '8.0', '9.0'],
-  node: ['14', '16', '18', '20', '22'],
-  next: ['20', '22'],
-  laravel: ['8.3.0', '8.2.0', '8.1.0', '8.0.0', '7.4.0', '7.3.0', '7.2.0'],
-  php: ['8.3.0', '8.2.0', '8.1.0', '8.0.0', '7.4.0', '7.3.0', '7.2.0'],
-  python: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12'],
-  django: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12'],
-  flask: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12'],
+interface IVersions {
+  [platform: string]: {
+    defaultVersion: string;
+    allVersions: string[];
+  };
+}
+const versions: IVersions = {
+  dotnet: {
+    defaultVersion: '6.0',
+    allVersions: [
+      '2.1',
+      '2.2',
+      '3.0',
+      '3.1',
+      '5.0',
+      '6.0',
+      '7.0',
+      '8.0',
+      '9.0',
+    ],
+  },
+  node: { defaultVersion: '20', allVersions: ['14', '16', '18', '20', '22'] },
+  next: { defaultVersion: '20', allVersions: ['20', '22'] },
+  laravel: {
+    defaultVersion: '8.0',
+    allVersions: [
+      '8.3.0',
+      '8.2.0',
+      '8.1.0',
+      '8.0.0',
+      '7.4.0',
+      '7.3.0',
+      '7.2.0',
+    ],
+  },
+  php: {
+    defaultVersion: '8.0',
+    allVersions: [
+      '8.3.0',
+      '8.2.0',
+      '8.1.0',
+      '8.0.0',
+      '7.4.0',
+      '7.3.0',
+      '7.2.0',
+    ],
+  },
+  python: {
+    defaultVersion: '3.11',
+    allVersions: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12'],
+  },
+  django: {
+    defaultVersion: '3.10',
+    allVersions: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12'],
+  },
+  flask: {
+    defaultVersion: '3.10',
+    allVersions: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12'],
+  },
 };
+// export const defaultVersion={
 
-type Platform = keyof typeof versions;
+// }
 
-export default function supportedVersions(platform: Platform) {
-  return versions[platform];
+export default function supportedVersions(platform: string) {
+  if (platform in versions) {
+    return versions[platform as keyof typeof versions];
+  }
+  return null;
 }

--- a/src/utils/promptPort.ts
+++ b/src/utils/promptPort.ts
@@ -1,0 +1,15 @@
+import inquirer from 'inquirer';
+import { getDefaultPort } from './get-port.js';
+import validatePort from './validate-port.js';
+
+export async function promptPort(platform: string): Promise<number> {
+  const { port } = (await inquirer.prompt({
+    name: 'port',
+    type: 'input',
+    default: getDefaultPort(platform),
+    message: 'Enter the port your app listens to:',
+    validate: validatePort,
+  })) as { port: number };
+
+  return port;
+}


### PR DESCRIPTION
This command provides an interactive process to generate a basic liara.json configuration file.
The generated configuration file will include only the basic parameters to get started, such as application name, port, platform, and other necessary fields. However, any additional or advanced configurations (such as cron, healthCheck, etc.) will not be included by default and must be manually added after the file is created.